### PR TITLE
Removed broken response_times_limit

### DIFF
--- a/src/ws/prometheus_uptimerobot/web.py
+++ b/src/ws/prometheus_uptimerobot/web.py
@@ -117,7 +117,6 @@ class UptimeRobotCollector(object):
             'format': 'json',
             'offset': offset,
             'response_times': '1',  # enable
-            'response_times_limit': '1',  # just the latest one
         }).json()
 
 


### PR DESCRIPTION
The removed line cause the request to fail.
I have no idea why, the documentation still mentions it. 